### PR TITLE
Updated course link for machine learning

### DIFF
--- a/docs/computer-science/applications/machine-learning/index.md
+++ b/docs/computer-science/applications/machine-learning/index.md
@@ -3,12 +3,8 @@ sidebar_position: 2
 ---
 
 # Machine Learning
-*Timeline: 99 hours*
+*Timeline: 50 hours*
 
 These courses provide a broad introduction to modern machine learning, including supervised learning (multiple linear regression, logistic regression, neural networks, and decision trees), unsupervised learning (clustering, dimensionality reduction, recommender systems), and some of the best practices used in Silicon Valley for artificial intelligence and machine learning innovation (evaluating and tuning models, taking a data-centric approach to improving performance, and more.)
 
-- [Supervised Machine Learning: Regression and Classification](https://www.coursera.org/learn/machine-learning), 33 hrs
-
-- [Advanced Learning Algorithms](https://www.coursera.org/learn/advanced-learning-algorithms), 34 hrs
-
-- [Unsupervised Learning, Recommenders, Reinforcement Learning](https://www.coursera.org/learn/unsupervised-learning-recommenders-reinforcement-learning), 27 hrs
+- [Machine Learning Specialization](https://www.deeplearning.ai/courses/machine-learning-specialization/)


### PR DESCRIPTION
Coursera has removed audit access most courses on their platform, including the machine learning specialization that we include in our curriculum.

DeepLearning.AI, which is the creator of this course, has a free membership option and access to free lecture videos and some code examples. Graded quizzes and labs are inaccessible behind a paywall, but this was similar to how Coursera operated before their change to audit access.