### PR TITLE
Change game theory link from coursera to roughgarden archive

### DIFF
--- a/docs/computer-science/advanced-cs/electives/index.md
+++ b/docs/computer-science/advanced-cs/electives/index.md
@@ -78,7 +78,7 @@ Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Theory of Computation](https://ocw.mit.edu/courses/18-404j-theory-of-computation-fall-2020/) ([alternative](https://www.youtube.com/playlist?list=PLEE7DF8F5E0203A56)) | 13 weeks | 10 hours/week | [Mathematics for Computer Science](https://openlearninglibrary.mit.edu/courses/course-v1:OCW+6.042J+2T2019/about), logic, algorithms
 [Computational Geometry](https://www.edx.org/learn/geometry/tsinghua-university-ji-suan-ji-he-computational-geometry) | 16 weeks | 8 hours/week | algorithms, C++
-[Game Theory](https://www.coursera.org/learn/game-theory-1) | 8 weeks | 3 hours/week | mathematical thinking, probability, calculus
+[Algorithmic Game Theory](https://timroughgarden.org/f13/f13.html) | 10 weeks | 12 hours/week | Algorithms Illuminated
 
 #### Advanced Information Security
 


### PR DESCRIPTION
As per [this suggestion](https://github.com/BorrProject/borrproject.github.io/issues/15#issuecomment-4020955419)

I was unable to find an explicit hour count.  Stanford runs on 10 week quarters, there are about 2.5 hours of lecture per week in addition to readings, weekly exercises, and biweekly problem sets.  12 hours per week seems reasonable but is probably an underestimate.