### PR TITLE
Revert "Update URL to the latest one"

### DIFF
--- a/docs/computer-science/program-design/object-oriented/index.md
+++ b/docs/computer-science/program-design/object-oriented/index.md
@@ -9,4 +9,4 @@ CS 3500 teaches a rigorous approach to object-oriented programming and design, w
 
 This course assumes familiarity with programming in the style of *[Systematic Program Design](../spd/index.md)*, and basic knowledge of the Java programming language as introduced in *[Class-Based Program Design](../class-based/index.md)*.
 
-- https://course.ccs.neu.edu/cs3500f19/
+- [CS 3500: Object-Oriented Design](https://course.ccs.neu.edu/cs3500f19/)

--- a/docs/computer-science/program-design/object-oriented/index.md
+++ b/docs/computer-science/program-design/object-oriented/index.md
@@ -9,4 +9,4 @@ CS 3500 teaches a rigorous approach to object-oriented programming and design, w
 
 This course assumes familiarity with programming in the style of *[Systematic Program Design](../spd/index.md)*, and basic knowledge of the Java programming language as introduced in *[Class-Based Program Design](../class-based/index.md)*.
 
-- [CS 3500: Object-Oriented Design](https://course.khoury.northeastern.edu/cs3500/)
+- https://course.ccs.neu.edu/cs3500f19/


### PR DESCRIPTION
Reverts BorrProject/borrproject.github.io#7

The course page linked in this PR does not have publicly accessible homeworks or labs.  It'd be best to revert to the 2019 version which has available homework assignments. 